### PR TITLE
fix(core): reset when field display is none should be keep value

### DIFF
--- a/packages/core/src/__tests__/internals.spec.ts
+++ b/packages/core/src/__tests__/internals.spec.ts
@@ -5,7 +5,7 @@ import {
   deserialize,
   isHTMLInputEvent,
 } from '../shared/internals'
-import { createForm } from '../'
+import { createForm, onFieldValueChange } from '../'
 import { attach } from './shared'
 
 test('getValuesFromEvent', () => {
@@ -108,4 +108,32 @@ test('isHTMLInputEvent', () => {
   expect(isHTMLInputEvent({ target: { tagName: 'DIV' } })).toBeFalsy()
   expect(isHTMLInputEvent({ target: {}, stopPropagation() {} })).toBeFalsy()
   expect(isHTMLInputEvent({})).toBeFalsy()
+})
+
+test('reset when field display is none should be keep value', () => {
+  const valueChange = jest.fn()
+  const form = attach(
+    createForm({
+      initialValues: {
+        input: '123',
+      },
+      effects: () => {
+        onFieldValueChange('input', valueChange)
+      },
+    })
+  )
+  attach(
+    form.createField({
+      name: 'input',
+    })
+  )
+  expect(form.values.input).toEqual('123')
+  form.fields['input'].setDisplay('none')
+  expect(form.values.input).toBeUndefined()
+  expect(valueChange).toBeCalledTimes(1)
+  form.reset()
+  form.reset()
+  form.fields['input'].setDisplay('visible')
+  expect(form.values.input).toEqual('123')
+  expect(valueChange).toBeCalledTimes(2)
 })

--- a/packages/core/src/shared/internals.ts
+++ b/packages/core/src/shared/internals.ts
@@ -995,6 +995,13 @@ export const resetSelf = batch.bound(
     target.inputValue = typedDefaultValue
     target.inputValues = []
     target.caches = {}
+    if (target.display === 'none') {
+      const value =
+        options?.forceClear || isUndef(target.initialValue)
+          ? typedDefaultValue
+          : toJS(target.initialValue)
+      target.caches.value = value
+    }
     if (!isUndef(target.value)) {
       if (options?.forceClear) {
         target.value = typedDefaultValue


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [ ] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [ ] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
